### PR TITLE
Fix memory leaks Issue #1

### DIFF
--- a/src/abctab2ps.cpp
+++ b/src/abctab2ps.cpp
@@ -231,11 +231,6 @@ int main(int argc, char **argv)
     printf("This is abctab2ps, version %s.%s (%s)\n", VERSION, REVISION, VDATE);
   }
 
-  alloc_structs ();
-
-  maxNwpool = allocNwpool;
-  wpool = (char *)zrealloc(NULL, 0, maxNwpool, sizeof(char));
-
   /* ----- set the page format ----- */
   nfontnames=0;
   if (!set_page_format()) exit (3);
@@ -256,6 +251,12 @@ int main(int argc, char **argv)
   if (epsf) cutext(outf);
   
   /* ----- initialize ----- */
+  
+  alloc_structs ();
+
+  maxNwpool = allocNwpool;
+  wpool = (char *)zrealloc(NULL, 0, maxNwpool, sizeof(char));
+
   zero_sym();
   pagenum=0;
   tunenum=tnum1=tnum2=0;
@@ -324,9 +325,17 @@ int main(int argc, char **argv)
   if (do_mode==DO_INDEX)
     printf ("Selected %d title%s of %d\n", tnum1, tnum1==1?"":"s", tnum2);
   
+  /* clean up files and memory */
+  
   if ((do_mode == DO_OUTPUT) && make_index) close_index_file ();
   rc = close_output_file ();
 
+  if (fin != NULL) fclose (fin);
+
+  free (wpool);
+  wpool=NULL;
+  free_structs ();
+  
   if ((do_mode == DO_OUTPUT) && rc)
     return 1;
   else

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -407,6 +407,7 @@ void set_minsyms(int ivc)
   printf ("set_minsyms:  n2=%d\n",n2);
   if (n2>0) return;
 
+  delete symv[ivc][n2].gchords;
   symv[ivc][n2]=zsym;
   symv[ivc][n2].gchords= new GchordList();
   symv[ivc][n2].type = INVISIBLE;
@@ -1052,6 +1053,7 @@ int set_initsyms (int v, float *wid0)
   k=0;
   
   /* add clef */
+  delete sym_st[v][k].gchords;
   sym_st[v][k]=zsym;
   sym_st[v][k].gchords= new GchordList();
   sym_st[v][k].type = CLEF;
@@ -1060,6 +1062,7 @@ int set_initsyms (int v, float *wid0)
   k++;
 
   /* add keysig */
+  delete sym_st[v][k].gchords;
   sym_st[v][k]=zsym;
   sym_st[v][k].gchords= new GchordList();
   sym_st[v][k].type = KEYSIG;
@@ -1074,6 +1077,7 @@ int set_initsyms (int v, float *wid0)
 
   /* add timesig */
   if (voice[ivc].meter.display) {
+    delete sym_st[v][k].gchords;
     sym_st[v][k]=zsym;
     sym_st[v][k].gchords= new GchordList();
     sym_st[v][k].type = TIMESIG;
@@ -1093,6 +1097,7 @@ int set_initsyms (int v, float *wid0)
   }
 
   if (voice[ivc].insert_btype) {
+    delete sym_st[v][k].gchords;
     sym_st[v][k]=zsym;
     sym_st[v][k].gchords= new GchordList();
     sym_st[v][k].type = BAR;
@@ -4768,7 +4773,7 @@ void output_music (FILE *fp)
 /* ----- process_textblock ----- */
 void process_textblock(FILE *fpin, FILE *fp, int job)
 {
-  char* w1;
+  char* w1 = NULL;
   string ln;
   float lwidth,baseskip,parskip;
   int i,ll,add_final_nl;
@@ -4809,6 +4814,8 @@ void process_textblock(FILE *fpin, FILE *fp, int job)
     }
   }
   if (job!=SKIP) write_text_block (fp,job);
+  
+  free(w1);
 }
 
 

--- a/src/subs.cpp
+++ b/src/subs.cpp
@@ -690,6 +690,46 @@ void realloc_structs (int newmaxSyms, int newmaxVc)
   maxVc=newmaxVc;
 }
 
+/* ----- free_structs ----- */
+void free_structs (void)
+{
+  int i, j;
+    
+  /* Don't delete gchords in sym as they are copies of those in symv and sym_st,
+     otherwise it would cause a double delete */
+  free(sym);
+  sym=NULL;
+
+  for (i=0;i<maxVc;i++) {
+    for (j=0;j<maxSyms;j++) {
+        delete symv[i][j].gchords;
+    }
+    free(symv[i]);
+  }
+  free(symv);
+  symv=NULL;
+
+  for (i=0;i<maxSyms+1;i++) {
+    free(xp[i].p);
+  }
+  free(xp);
+  xp=NULL;
+
+  free(voice);
+  voice=NULL;
+
+  for (i=0;i<maxVc;i++) {
+    for (j=0;j<MAXSYMST;j++) {
+        delete sym_st[i][j].gchords;
+    }
+    free(sym_st[i]);
+  }
+  free(sym_st);
+  sym_st=NULL;
+
+  free(nsym_st);
+  nsym_st=NULL;
+}
 
 /* ----- set_page_format ----- */
 int set_page_format (void)

--- a/src/subs.h
+++ b/src/subs.h
@@ -36,6 +36,7 @@ void process_cmdline (char *line);
 void *zrealloc(void* addr, size_t nold, size_t nnew, size_t size);
 void alloc_structs (void);
 void realloc_structs (int newmaxSyms, int newmaxVc);
+void free_structs (void);
 
 /* ----- set_page_format ----- */
 int set_page_format (void);


### PR DESCRIPTION
Fix memory leaks Issue #1.

The memory leaks are in parse.cpp and music.cpp and are caused by not deleting the gchords member before overwriting the whole SYMBOL structure.  This occurs in several places.

The other changes I have made are to free memory before program exist, not strictly necessary, this is just being tidy.  It fixes all the valgrind error reports.

After applying my fixes:

valgrind -s --leak-check=full --show-leak-kinds=all --track-origins=yes ./abctab2ps ../doc/examples/francisque.abc
==23397== Memcheck, a memory error detector
==23397== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==23397== Using Valgrind-3.20.0 and LibVEX; rerun with -h for copyright info
==23397== Command: ./abctab2ps ../doc/examples/francisque.abc
==23397== 
This is abctab2ps, version 1.8.25 (Oct 22 2023)
../doc/examples/francisque.abc: [1] Premier Branle de Poitou - 
Output written on Out.ps (1 page, 1 title, 72113 bytes)
==23397== 
==23397== HEAP SUMMARY:
==23397==     in use at exit: 0 bytes in 0 blocks
==23397==   total heap usage: 1,095 allocs, 1,095 frees, 4,189,595 bytes allocated
==23397== 
==23397== All heap blocks were freed -- no leaks are possible
==23397== 
==23397== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

I've tested my fixes on the .abc examples and successfully generated their .pdf files.

